### PR TITLE
Fix InventoryService lint issues (in a massively-breaking way)

### DIFF
--- a/edgebit/agent/v1alpha/inventory_service.proto
+++ b/edgebit/agent/v1alpha/inventory_service.proto
@@ -1,31 +1,34 @@
 syntax = "proto3";
-package edgebit.v1alpha.inventory;
+package edgebit.agent.v1alpha;
 
 /*
  * InventoryService is used to report which packages are installed and are in-use
  */
 service InventoryService {
     // Uploads the SBOM of an node
-    rpc UploadSbom(stream UploadSbomRequest) returns (Void) {};
+    rpc UploadSbom(stream UploadSbomRequest) returns (UploadSbomResponse) {};
 
     // Report files that were used (open) on the machine
-    rpc ReportInUse(ReportInUseRequest) returns (Void) {};
+    rpc ReportInUse(ReportInUseRequest) returns (ReportInUseResponse) {};
 }
 
 enum SbomFormat {
-	SBOMFMT_SYFT = 0;
+    SBOM_FORMAT_UNSPECIFIED = 0;
+    SBOM_FORMAT_SYFT = 1;
 }
 
 message UploadSbomHeader {
-	SbomFormat format = 1;
+    SbomFormat format = 1;
 }
 
 message UploadSbomRequest {
-	oneof kind {
-		UploadSbomHeader header = 1;
-		bytes data = 2;
-	}
+    oneof kind {
+        UploadSbomHeader header = 1;
+        bytes data = 2;
+    }
 }
+
+message UploadSbomResponse {}
 
 message PkgInUse {
     // id of the package as was identified by the id field of Rpm/Deb/etc.
@@ -38,4 +41,4 @@ message ReportInUseRequest {
     repeated PkgInUse in_use = 1;
 }
 
-message Void {}
+message ReportInUseResponse {}


### PR DESCRIPTION
1. Move the Inventory service to `edgebit.agent.v1alpha`
2. Replace `Void` messages with a unique type per RPC (flagged by the linter, I think this is intended to make it easy to evolve these types over time)
3. Change `SBOMFMT_` enum prefix to `SBOM_FORMAT` to satisfy linter
4. Add a new zero-value `SBOM_FORMAT_UNSPECIFIED` enum item to satisfy linter (intended to make sure that unset enums can be differentiated from `SBOM_FORMAT_SYFT`)