### PR TITLE
Autofix: add confidence score

### DIFF
--- a/edgebit/v1alpha/autofix_service.proto
+++ b/edgebit/v1alpha/autofix_service.proto
@@ -110,4 +110,7 @@ message FetchAnalysisResultsResponse {
 
     // Per changed symbol behavior summary
     repeated SymbolAnalysis symbol_behavior = 6;
+
+    // Overall accuracy confidence score
+    double confidence = 7;
 }


### PR DESCRIPTION
A PR to start discussion about the components of the confidence score and their relative weights.
Some rough ideas for components:

- How often it failed to locate upstream sources
- How many module import errors we got
- How often symbols failed to resolve